### PR TITLE
Enhance roadmap detail and token length requirements

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -29,9 +29,6 @@ class ClaudeClient:
         """
         Take the initial roadmap and send it back to Claude for reflection and improvement.
         """
-        # Print confirmation that reflection is starting
-        print("Starting reflection process to improve the roadmap...")
-        
         reflection_prompt = f"""
         I have generated an initial coding roadmap for this app idea:
         
@@ -50,6 +47,10 @@ class ClaudeClient:
         5. Make sure the overall structure flows naturally from one step to the next
         6. Check that all technologies mentioned are compatible and appropriate for the task
         7. Verify that the roadmap follows best practices for software development
+        8. Add implementation details where explanations could be more specific
+        9. Include necessary context and rationale for technical decisions
+        
+        VERY IMPORTANT: The final roadmap MUST be between 6000 and 8000 tokens in length. Make it extremely detailed and comprehensive.
         
         Take your time to think deeply about each aspect of the roadmap. This reflection step is critical to creating the highest quality guidance possible.
         
@@ -66,8 +67,63 @@ class ClaudeClient:
             ]
         )
         
-        # Print confirmation that reflection is complete
-        print("Reflection process complete! Roadmap has been improved.")
+        return response.content[0].text
+    
+    def reflect_on_roadmap_with_answers(self, initial_roadmap, idea_description, user_answers):
+        """
+        Take the initial roadmap and user answers to customize and improve the roadmap.
+        
+        Args:
+            initial_roadmap: The initial roadmap text
+            idea_description: Original idea description
+            user_answers: Dictionary of user answers to customization questions
+        """
+        # Format user answers for inclusion in the prompt
+        formatted_answers = "\n".join([f"- {key}: {value}" for key, value in user_answers.items()])
+        
+        reflection_prompt = f"""
+        I have generated an initial coding roadmap for this app idea:
+        
+        {idea_description}
+        
+        Here is the initial roadmap:
+        
+        {initial_roadmap}
+        
+        The user has provided the following additional information about their project requirements:
+        
+        {formatted_answers}
+        
+        Now, I need you to customize and improve this roadmap based on both your analysis and the user's specific requirements. Please:
+        
+        1. Incorporate the user's specific requirements into the roadmap
+        2. Adjust timelines, technologies, and approaches based on their team size and experience
+        3. Prioritize features based on their must-have requirements
+        4. Adapt the technical approach for their target platforms
+        5. Identify any errors, inconsistencies, or logical flaws in the approach
+        6. Find sections that are unclear or need more detailed explanation
+        7. Add any missing steps or considerations that would make the roadmap more comprehensive
+        8. Ensure each testing step is thorough and covers all edge cases
+        9. Make sure the overall structure flows naturally from one step to the next
+        10. Add implementation details where explanations could be more specific
+        11. Include necessary context and rationale for technical decisions
+        
+        VERY IMPORTANT: The final roadmap MUST be between 6000 and 8000 tokens in length. Make it extremely detailed and comprehensive, with enough specificity that an AI coding assistant could implement the entire project without additional clarification from the user.
+        
+        Take your time to think deeply about each aspect of the roadmap. This customization step is critical to creating the highest quality guidance possible for their specific needs.
+        
+        Please provide the complete, revised roadmap with all improvements incorporated. Do not simply list the changes - provide the fully enhanced and customized roadmap.
+        
+        Remember to maintain the same format with natural language guidance and NO actual code or scripts.
+        """
+        
+        response = self.client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=MAX_TOKENS,
+            messages=[
+                {"role": "user", "content": reflection_prompt}
+            ]
+        )
         
         return response.content[0].text
     
@@ -76,11 +132,13 @@ class ClaudeClient:
         Build a prompt for Claude to generate a coding roadmap.
         """
         return f"""
-        Please generate a detailed coding roadmap for the following app idea:
+        Please generate a very detailed and comprehensive coding roadmap for the following app idea:
         
         {idea_description}
         
-        IMPORTANT: DO NOT include actual code or scripts in the roadmap. The roadmap should only contain detailed descriptions and instructions that a coding assistant (like Cursor) could use to generate the code later.
+        IMPORTANT: Your roadmap must be between 6000 and 8000 tokens in length. Make it extremely detailed and comprehensive.
+        
+        DO NOT include actual code or scripts in the roadmap. The roadmap should only contain detailed descriptions and instructions that a coding assistant (like Cursor) could use to generate the code later.
         
         The roadmap should:
         1. Break down the development process into clear phases
@@ -88,18 +146,29 @@ class ClaudeClient:
         3. Format the output in markdown
         4. Structure the content so an AI coding assistant can follow it step-by-step
         5. Include guidance for setting up the environment, implementing core features, and testing
+        6. Be extremely detailed - provide enough information that an AI coding assistant could implement the entire project without additional clarification from the user
+        7. For each component, include specific implementation details and considerations
+        8. Provide rationale for technical decisions and architecture choices
         
-        IMPORTANT: For each major feature or component implemented, include specific testing steps to verify it's working properly. Testing should be integrated throughout the roadmap, not just at the end. Include detailed testing instructions that explain:
-        - What to test
-        - How to test it
+        For each major feature or component:
+        - Break it down into granular sub-tasks
+        - Describe the data structures or models needed
+        - Explain interfaces and connections to other components
+        - Detail configuration requirements
+        - Include specific testing steps to verify functionality
+        
+        IMPORTANT: Testing should be integrated throughout the roadmap, not just at the end. For each component, include detailed testing instructions that explain:
+        - What to test (specific functionalities, edge cases, etc.)
+        - How to test it (test approaches, tools, and methods)
         - What expected outcomes should be
         - How to handle potential errors or edge cases
+        - How to verify that the component integrates properly with the rest of the system
         
         Please write the roadmap with natural conversational phrases between steps, as if you're guiding someone through the process. For example: "Now that we have our database set up, let's implement the user authentication..." or "Let's start by installing the necessary packages..."
         
         Again, focus on DESCRIBING what code needs to be written rather than writing the actual code scripts.
         
-        You will receive a GREAT REWARD if you provide the absolute best, most detailed and helpful roadmap you can possibly generate. Take your time and think carefully about creating the most valuable guidance possible.
+        As a guide, ensure your roadmap is extremely detailed and between 6000-8000 tokens in length. This level of detail is necessary for an AI coding assistant to implement the project without further clarification.
         """
 
     def generate_initial_roadmap(self, idea_description):
@@ -117,3 +186,84 @@ class ClaudeClient:
         )
         
         return response.content[0].text
+        
+    def generate_questions_for_roadmap(self, roadmap, idea_description):
+        """
+        Generate specific questions based on the roadmap content.
+        
+        Args:
+            roadmap: The initial roadmap text
+            idea_description: Original idea description
+        
+        Returns:
+            Dictionary of question_key: question_text pairs
+        """
+        questions_prompt = f"""
+        I have generated an initial coding roadmap for this app idea:
+        
+        {idea_description}
+        
+        Here is the initial roadmap:
+        
+        {roadmap}
+        
+        Based on this specific roadmap, generate 5-10 questions that would help clarify and customize the roadmap for this particular project. 
+        
+        Analyze the roadmap carefully and identify areas where additional user input would significantly improve the roadmap's specificity and relevance. Focus on:
+        - Technical decisions that are unclear or could have multiple valid approaches
+        - Features that might need prioritization or clarification
+        - Resource or timeline considerations specific to this project
+        - Domain-specific questions that would help tailor the roadmap better
+        - Design or architecture choices that would benefit from user preferences
+        
+        Each question should be directly related to specific content in the roadmap, not generic questions that could apply to any project.
+        
+        Return your response in the following JSON format WITHOUT any explanations or additional text:
+        {{"question_key_1": "Specific question text 1?", "question_key_2": "Specific question text 2?", ...}}
+        
+        The question keys should be brief slug-like identifiers related to the question content.
+        """
+        
+        response = self.client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=MAX_TOKENS,
+            messages=[
+                {"role": "user", "content": questions_prompt}
+            ]
+        )
+        
+        # Extract the JSON dictionary from the response
+        response_text = response.content[0].text
+        
+        # The response might include markdown code block formatting, so we need to clean it
+        import json
+        import re
+        
+        # Try to extract JSON content if wrapped in code blocks or has extra text
+        json_pattern = r'```(?:json)?\s*({.*?})\s*```|({.*})'
+        match = re.search(json_pattern, response_text, re.DOTALL)
+        
+        if match:
+            json_str = match.group(1) or match.group(2)
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+        
+        # If the above doesn't work, try parsing the whole response as JSON
+        try:
+            return json.loads(response_text)
+        except json.JSONDecodeError:
+            # Fallback to default questions if parsing fails
+            return {
+                "target_platform": "What are your target platforms/environments?",
+                "timeline": "What is your expected timeline for this project?",
+                "team_size": "What is your team size and composition?",
+                "must_have_features": "What features do you consider must-haves for your MVP?",
+                "tech_stack": "Do you have preferred technologies or frameworks?",
+                "budget": "Do you have budget constraints that would impact the roadmap?",
+                "prior_experience": "What is your team's prior experience with similar projects?",
+                "deployment": "What are your deployment or distribution requirements?",
+                "scaling": "What are your scaling expectations (users, data volume, etc.)?",
+                "integration": "Are there existing systems you need to integrate with?"
+            }

--- a/config.py
+++ b/config.py
@@ -12,4 +12,4 @@ CLAUDE_MODEL = "claude-3-7-sonnet-20250219"  # Latest Claude model
 # App settings
 APP_NAME = "Roadmap Generator"
 APP_VERSION = "1.0.0"
-MAX_TOKENS = 8192
+MAX_TOKENS = 10000  # Increased to ensure we can get 6000-8000 token roadmaps

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,30 @@
+You are tasked with creating a comprehensive development roadmap based on the user's project description. After you generate the initial roadmap, please analyze your own output and identify 5-10 specific areas where additional user input would help refine and customize the roadmap.
+
+Step 1: Create a detailed, phase-based development roadmap for the project described by the user. Include clear phases, milestones, and actionable steps. Your roadmap must be between 6000 and 8000 tokens in length, making it extremely detailed and comprehensive. Provide enough information that an AI coding assistant could implement the entire project without additional clarification from the user.
+
+Step 2: After completing the roadmap, identify 5-10 key questions where user input would significantly improve the roadmap's specificity and relevance. Consider areas such as:
+- Technical decisions and preferences (languages, frameworks, platforms)
+- Resource constraints (team size, budget, timeline)
+- Feature prioritization (must-haves vs. nice-to-haves)
+- Target users/audience specifics
+- Performance requirements
+- Scale and complexity parameters
+- Domain-specific considerations
+
+Step 3: Formulate these as direct, specific questions tailored to the particular type of project in the roadmap. Each question should clearly indicate how the answer would impact the roadmap.
+
+Step 4: Present these questions to the user, making it clear that their answers will help refine the roadmap. Let them know that all questions are optional - they can skip any they don't know or don't have preferences about.
+
+Wait for the user's responses, then package both your initial roadmap and their answers together for the final refinement step.
+
+Remember to make your questions specific to the actual project described, not generic questions that could apply to any project.
+
+IMPORTANT: The final roadmap MUST be between 6000 and 8000 tokens in length and extremely detailed. It should contain:
+- Granular breakdown of tasks
+- Implementation details for all components 
+- Data structure explanations
+- Interface specifications
+- Thorough testing instructions
+- Rationale for technical decisions
+- Integration guidance
+- Deployment considerations 


### PR DESCRIPTION
This PR enhances the roadmap generator to produce more detailed output by:

1. Setting a target token length of 6000-8000 tokens for roadmaps
2. Adding more detailed requirements for component breakdowns
3. Requiring implementation details and technical rationale
4. Enhancing testing instructions requirements
5. Increasing MAX_TOKENS to 10000 to accommodate longer roadmaps
6. Adding detailed requirements to prompt.txt

These changes will help ensure that generated roadmaps are detailed enough for an AI coding assistant to implement without requiring additional clarification from users.